### PR TITLE
docs: fix README background link typo

### DIFF
--- a/.changeset/docs-background-fix.md
+++ b/.changeset/docs-background-fix.md
@@ -1,0 +1,4 @@
+---
+"fhir-beacon": patch
+---
+Fix README background link text.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A FHIR data library for the frontend.
 * library docs: [library](./packages/library/README.md).
 * storybook: https://fhir-beacon.deno.dev
 * showcase: https://fhir-beacon-app.deno.dev
-* for details about the project read the [backround](./packages/library/docs/background.md)
+* for details about the project read the [background](./packages/library/docs/background.md)
     
 ## Usage example:
 ```typescript


### PR DESCRIPTION
## Summary
- fix README background link text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68610cd3a8688331a200e9f43e02c39d