### PR TITLE
fix: treat falsy values as defined in hasAll

### DIFF
--- a/.changeset/fix-falsy-values.md
+++ b/.changeset/fix-falsy-values.md
@@ -1,0 +1,4 @@
+---
+"fhir-beacon": patch
+---
+Treat falsy property values as defined in `hasAll`.

--- a/packages/library/src/utilities/hasAll.test.ts
+++ b/packages/library/src/utilities/hasAll.test.ts
@@ -4,6 +4,7 @@ import {hasAll}                 from './hasAll'
 describe('function: has all', () => {
 
   const obj = { a: 'aa', b: 'bb', c: 'cc', d: 'dd' }
+  const falsyObj = { a: 0, b: '', c: false }
 
   test('should find all properties', () => {
     expect(hasAll(obj, ['a', 'c'])).to.equal(true)
@@ -23,5 +24,13 @@ describe('function: has all', () => {
 
   test('should not find all properties in superset', () => {
     expect(hasAll(obj, ['a', 'b', 'c', 'd', 'e'])).to.equal(false)
+  })
+
+  test('should treat falsy values as defined', () => {
+    expect(hasAll(falsyObj, ['a', 'b', 'c'])).to.equal(true)
+  })
+
+  test('should detect missing property with falsy values', () => {
+    expect(hasAll(falsyObj, ['a', 'b', 'c', 'd'])).to.equal(false)
   })
 })

--- a/packages/library/src/utilities/hasAll.ts
+++ b/packages/library/src/utilities/hasAll.ts
@@ -5,5 +5,5 @@
  * @param props the properties to check for
  */
 export function hasAll(obj: any, props: string[]) {
-  return props.reduce((acc, p) => Object.prototype.hasOwnProperty.call(obj, p) && obj[p] && acc, true)
+  return props.reduce((acc, p) => Object.prototype.hasOwnProperty.call(obj, p) && acc, true)
 }


### PR DESCRIPTION
## Summary
- update `hasAll` to only check that properties exist
- extend `hasAll` tests with falsy property cases

## Testing
- `npm test` *(fails: Playwright download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68610d7b525883319c305a136b53e1b2